### PR TITLE
Special empty string handling to adviser filter

### DIFF
--- a/retention_dashboard/dao/data.py
+++ b/retention_dashboard/dao/data.py
@@ -56,6 +56,8 @@ def get_filtered_data(type, week,
     if text_filter:
         dataset = DataPoint.filter_by_text(dataset, text_filter)
     if advisor_filter:
+        if advisor_filter == "no_assigned_adviser":
+            advisor_filter = ""  # query using empty string
         dataset = DataPoint.filter_by_advisor(dataset, advisor_filter)
     if summer_filters:
         dataset = DataPoint.filter_by_summer(dataset, summer_filters)

--- a/retention_dashboard/models.py
+++ b/retention_dashboard/models.py
@@ -191,12 +191,15 @@ class Advisor(models.Model):
 
     @staticmethod
     def get_all_advisors():
-        eop = Advisor.objects.filter(advisor_type=2).\
-            values('advisor_name', 'advisor_netid')
-        prem = Advisor.objects.filter(advisor_type=1).\
-            values('advisor_name', 'advisor_netid')
-        inter = Advisor.objects.filter(advisor_type=3).\
-            values('advisor_name', 'advisor_netid')
+        eop = Advisor.objects.filter(advisor_type=2) \
+            .order_by('advisor_name') \
+            .values('advisor_name', 'advisor_netid')
+        prem = Advisor.objects.filter(advisor_type=1) \
+            .order_by('advisor_name') \
+            .values('advisor_name', 'advisor_netid')
+        inter = Advisor.objects.filter(advisor_type=3) \
+            .order_by('advisor_name') \
+            .values('advisor_name', 'advisor_netid')
         return {"EOP": list(eop),
                 "Premajor": list(prem),
                 "International": list(inter)}

--- a/retention_dashboard/models.py
+++ b/retention_dashboard/models.py
@@ -193,12 +193,15 @@ class Advisor(models.Model):
     def get_all_advisors():
         eop = Advisor.objects.filter(advisor_type=2) \
             .order_by('advisor_name') \
+            .filter(~Q(advisor_name="")) \
             .values('advisor_name', 'advisor_netid')
         prem = Advisor.objects.filter(advisor_type=1) \
+            .filter(~Q(advisor_name="")) \
             .order_by('advisor_name') \
             .values('advisor_name', 'advisor_netid')
         inter = Advisor.objects.filter(advisor_type=3) \
             .order_by('advisor_name') \
+            .filter(~Q(advisor_name="")) \
             .values('advisor_name', 'advisor_netid')
         return {"EOP": list(eop),
                 "Premajor": list(prem),

--- a/retention_dashboard/static/retention_dashboard/js/components/Filters.vue
+++ b/retention_dashboard/static/retention_dashboard/js/components/Filters.vue
@@ -31,6 +31,9 @@
               <b-form-select-option :value="1" selected>
                 All advisors
               </b-form-select-option>
+              <b-form-select-option :value="'no_assigned_adviser'" selected>
+                No assigned adviser
+              </b-form-select-option>
             </template>
           </b-form-select>
         </b-form-group>

--- a/retention_dashboard/templates/admin.html
+++ b/retention_dashboard/templates/admin.html
@@ -256,14 +256,13 @@
       <p>Important notes:
         <ul>
           <li>Requires a zip file of the directory structure.</li>
-          <li>The "Delete existing data" removes all Advisor, Week, Datapoint, and Upload entries before the bulk upload.</li>
+          <li>The "Delete existing data" checkbox option removes all Advisor, Week, Datapoint, and Upload entries before the bulk upload.</li>
+          <li>Week, Advisor, DataPoint and Upload objects are automatically created by the bulk upload.</li>
           <li>The quarter, year, and week values are automatically extracted from the directory names.</li>
           <li>Quarter directory names must be "spr" (Spring), "su" (Summer), "au" (Autumn), or "wtr" (Winter), followed by a two digit year.</li>
           <li>Week directory names must be plain numbers or include the "week-" prefix.</li>
-          <li>Week objects are automatically created by the bulk upload.</li>
           <li>File names must be either "premajor-students.csv", "eop-students.csv", or "international-students.csv".</li>
           <li>Files that fail the unique combined week and file-type database contraint will be skipped.</li>
-          <li>A log file is downloaded once the upload process is completed.</li>
         </ul>
       </p>
       <form id="bulk_data_form">


### PR DESCRIPTION
Adds special handling for empty strings to the adviser filter. A new drop down option "No assigned adviser" has been added. Selecting this option, queries for all cases where students have their adviser set to "" (Not assigned). 