### PR TITLE
Pin django-webpack-loader to version 0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'Django~=2.2',
         'UW-Django-SAML2~=1.5',
-        'django-webpack-loader',
+        'django-webpack-loader==0.7.0',
         'django-userservice~=3.1',
     ],
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Pin `django-webpack-loader==0.7.0` as the latest version`django-webpack-loader==1.0.0` is not compatible with `webpack-bundle-tracker<1.0.0`