### PR TITLE
Adds support for RAD file format containing a adviser_type column

### DIFF
--- a/retention_dashboard/dao/admin.py
+++ b/retention_dashboard/dao/admin.py
@@ -135,7 +135,7 @@ class UploadDataDao():
         if bool(int(row.get("international", 0))) is True:
             upload_types.append(UploadTypes.international)
         if bool(int(row.get("isso", 0))) is True:
-            upload_types.append(UploadTypes.isso)
+            upload_types.append(UploadTypes.iss)
         if int(row.get("campus_code", 0)) == 2:
             upload_types.append(UploadTypes.tacoma)
         # premajor only if not any other classification

--- a/retention_dashboard/models.py
+++ b/retention_dashboard/models.py
@@ -45,9 +45,20 @@ class Week(models.Model):
                              f"sis_term_id={sis_term_id}")
 
 
+class UploadTypes():
+    premajor = 1
+    eop = 2
+    international = 3
+    iss = 4
+    tacoma = 5
+
+
 class DataPoint(models.Model):
-    TYPE_CHOICES = ((1, "Premajor"), (2, "EOP"), (3, "International"),
-                    (4, "ISS"), (5, "Tacoma"))
+    TYPE_CHOICES = ((UploadTypes.premajor, "Premajor"),
+                    (UploadTypes.eop, "EOP"),
+                    (UploadTypes.international, "International"),
+                    (UploadTypes.iss, "ISS"),
+                    (UploadTypes.tacoma, "Tacoma"))
     type = models.PositiveSmallIntegerField(choices=TYPE_CHOICES)
     week = models.ForeignKey("Week", on_delete=models.PROTECT)
     student_name = models.TextField()

--- a/retention_dashboard/tests/test_admin_dao.py
+++ b/retention_dashboard/tests/test_admin_dao.py
@@ -98,9 +98,9 @@ class TestUploadDataDao(TestCase):
              ('activity', '-4.00000000000000000000'),
              ('assignments', '-2.50000000000000000000'),
              ('grades', '0E-20'), ('pred', '4.699061188134724'),
-             ('adviser_name', 'Osure Brown'), ('staff_id', 'osureb'),
-             ('sign_in', '-0.3887894787550641'), ('stem', '1'),
-             ('incoming_freshman', '0'), ('premajor', '1'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', ''),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
              ('eop', '0'), ('international', '0'), ('isso', '0'),
              ('campus_code', '0'), ('summer', 'A-B')])
         self.assertEqual(dao.get_upload_types(row), [1])
@@ -110,9 +110,9 @@ class TestUploadDataDao(TestCase):
              ('activity', '-4.00000000000000000000'),
              ('assignments', '-2.50000000000000000000'),
              ('grades', '0E-20'), ('pred', '4.699061188134724'),
-             ('adviser_name', 'Osure Brown'), ('staff_id', 'osureb'),
-             ('sign_in', '-0.3887894787550641'), ('stem', '1'),
-             ('incoming_freshman', '0'), ('premajor', '0'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', ''),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '0'),
              ('eop', '1'), ('international', '0'), ('isso', '0'),
              ('campus_code', '0'), ('summer', 'A-B')])
         self.assertEqual(dao.get_upload_types(row), [2])
@@ -122,9 +122,9 @@ class TestUploadDataDao(TestCase):
              ('activity', '-4.00000000000000000000'),
              ('assignments', '-2.50000000000000000000'),
              ('grades', '0E-20'), ('pred', '4.699061188134724'),
-             ('adviser_name', 'Osure Brown'), ('staff_id', 'osureb'),
-             ('sign_in', '-0.3887894787550641'), ('stem', '1'),
-             ('incoming_freshman', '0'), ('premajor', '1'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', ''),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
              ('eop', '1'), ('international', '0'), ('isso', '0'),
              ('campus_code', '0'), ('summer', 'A-B')])
         self.assertEqual(dao.get_upload_types(row), [2])
@@ -134,9 +134,9 @@ class TestUploadDataDao(TestCase):
              ('activity', '-4.00000000000000000000'),
              ('assignments', '-2.50000000000000000000'),
              ('grades', '0E-20'), ('pred', '4.699061188134724'),
-             ('adviser_name', 'Osure Brown'), ('staff_id', 'osureb'),
-             ('sign_in', '-0.3887894787550641'), ('stem', '1'),
-             ('incoming_freshman', '0'), ('premajor', '1'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', ''),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
              ('eop', '0'), ('international', '1'), ('isso', '0'),
              ('campus_code', '2'), ('summer', 'A-B')])
         self.assertEqual(dao.get_upload_types(row), [3, 5])
@@ -146,9 +146,47 @@ class TestUploadDataDao(TestCase):
              ('activity', '-4.00000000000000000000'),
              ('assignments', '-2.50000000000000000000'),
              ('grades', '0E-20'), ('pred', '4.699061188134724'),
-             ('adviser_name', 'Osure Brown'), ('staff_id', 'osureb'),
-             ('sign_in', '-0.3887894787550641'), ('stem', '1'),
-             ('incoming_freshman', '0'), ('premajor', '1'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', ''),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
+             ('eop', '0'), ('international', '1'), ('isso', '1'),
+             ('campus_code', '2'), ('summer', 'A-B')])
+        self.assertEqual(dao.get_upload_types(row), [3, 4, 5])
+        # test for when adviser_type is set
+        row = OrderedDict(
+            [('uw_netid', 'fairsp'), ('student_no', '1864017'),
+             ('student_name_lowc', 'fairservice,peyton scott'),
+             ('activity', '-4.00000000000000000000'),
+             ('assignments', '-2.50000000000000000000'),
+             ('grades', '0E-20'), ('pred', '4.699061188134724'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', 'eop'),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
+             ('eop', '0'), ('international', '1'), ('isso', '1'),
+             ('campus_code', '2'), ('summer', 'A-B')])
+        self.assertEqual(dao.get_upload_types(row), [2])
+        row = OrderedDict(
+            [('uw_netid', 'fairsp'), ('student_no', '1864017'),
+             ('student_name_lowc', 'fairservice,peyton scott'),
+             ('activity', '-4.00000000000000000000'),
+             ('assignments', '-2.50000000000000000000'),
+             ('grades', '0E-20'), ('pred', '4.699061188134724'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', 'iss'),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
+             ('eop', '0'), ('international', '1'), ('isso', '1'),
+             ('campus_code', '2'), ('summer', 'A-B')])
+        self.assertEqual(dao.get_upload_types(row), [4])
+        # case where adviser type was unknown
+        row = OrderedDict(
+            [('uw_netid', 'fairsp'), ('student_no', '1864017'),
+             ('student_name_lowc', 'fairservice,peyton scott'),
+             ('activity', '-4.00000000000000000000'),
+             ('assignments', '-2.50000000000000000000'),
+             ('grades', '0E-20'), ('pred', '4.699061188134724'),
+             ('adviser_name', 'Osure Brown'), ('adviser_type', 'foobar'),
+             ('staff_id', 'osureb'), ('sign_in', '-0.3887894787550641'),
+             ('stem', '1'), ('incoming_freshman', '0'), ('premajor', '1'),
              ('eop', '0'), ('international', '1'), ('isso', '1'),
              ('campus_code', '2'), ('summer', 'A-B')])
         self.assertEqual(dao.get_upload_types(row), [3, 4, 5])


### PR DESCRIPTION
Fixes bug where an adviser could be associated with the wrong upload type (eop, iss, international, tacoma, etc.)