### PR TITLE
Fixes bug where advisors with an empty name could be incorrectly assigned

### DIFF
--- a/retention_dashboard/dao/admin.py
+++ b/retention_dashboard/dao/admin.py
@@ -163,7 +163,9 @@ class UploadDataDao():
                 advisor_name = row.get("adviser_name")
                 advisor = None
                 if advisor_netid is not None and advisor_name is not None:
-                    if advisor_netid not in advisor_dict:
+                    advisor_key = "{}_{}".format(advisor_netid,
+                                                 upload_type)
+                    if advisor_key not in advisor_dict:
                         try:
                             advisor = Advisor.objects.get(
                                                 advisor_netid=advisor_netid,
@@ -174,9 +176,9 @@ class UploadDataDao():
                                                 advisor_netid=advisor_netid,
                                                 advisor_type=upload_type,
                                                 advisor_name=advisor_name)
-                        advisor_dict[advisor_netid] = advisor
+                        advisor_dict[advisor_key] = advisor
                     else:
-                        advisor = advisor_dict[advisor_netid]
+                        advisor = advisor_dict[advisor_key]
                 has_a, has_b, has_full = \
                     self.get_summer_terms_from_string(row.get('summer'))
                 dp = DataPoint()

--- a/retention_dashboard/models.py
+++ b/retention_dashboard/models.py
@@ -171,9 +171,9 @@ class DataPoint(models.Model):
     @staticmethod
     def filter_by_advisor(data_queryset, advisor_netid, advisor_type):
         advisor_type_id = DataPoint.get_data_type_by_text(advisor_type)
-        advisor = Advisor.objects.get(advisor_netid=advisor_netid,
-                                      advisor_type=advisor_type_id)
-        return data_queryset.filter(advisor=advisor)
+        return (data_queryset
+                .filter(advisor__advisor_netid=advisor_netid)
+                .filter(advisor__advisor_type=advisor_type_id))
 
     def get_summer_string(self):
         term_list = []


### PR DESCRIPTION
Fix bug where data points with no advisor name could possibly be associated with an adviser from an incorrect upload type