### PR TITLE
Don't include file in uploads query

### DIFF
--- a/retention_dashboard/views/api/admin.py
+++ b/retention_dashboard/views/api/admin.py
@@ -127,8 +127,9 @@ class MockDataAdmin(RESTDispatch):
 class UploadListAdmin(RESTDispatch):
 
     def get(self, request):
-        uploads = list(Upload.objects.all().order_by(
-            'week__year', 'week__quarter', 'week__number', 'type'))
+        uploads = Upload.objects.all().order_by(
+            'week__year', 'week__quarter',
+            'week__number', 'type').defer('file')
         context = [upload.json_data() for upload in uploads]
         return self.json_response(content=context)
 


### PR DESCRIPTION
- speed up admin uploads query by omitting the file 