### PR TITLE
Bug fix decoding RAD content downloaded from a GCS bucket

### DIFF
--- a/retention_dashboard/dao/admin.py
+++ b/retention_dashboard/dao/admin.py
@@ -72,9 +72,9 @@ class StorageDao():
         :param url_key: Path of the content to upload
         :type url_key: str
         """
-        with default_storage.open(url_key, mode='r') as f:
+        with default_storage.open(url_key, mode='rb') as f:
             content = f.read()
-            return content
+            return content.decode('utf-8')
 
 
 class UploadDataDao():


### PR DESCRIPTION
- Add back utf-8 decoding for rad file content downloaded from bucket.
- Read file content in byte mode